### PR TITLE
init refactoring

### DIFF
--- a/src/napari_graph/_base_graph.py
+++ b/src/napari_graph/_base_graph.py
@@ -7,9 +7,7 @@ from numba import njit, typed
 from numba.core import types
 from numpy.typing import ArrayLike
 
-"""
-_EDGE_EMPTY_PTR is used to fill the values of uninitialized/empty/removed nodes or edges
-"""
+_NODE_EMPTY_PTR = -1
 _EDGE_EMPTY_PTR = -1
 
 
@@ -171,8 +169,6 @@ class BaseGraph:
         Optional number of edges to pre-allocate in the graph.
     """
 
-    _NODE_EMPTY_PTR = -1
-
     # abstract constants
     _EDGE_DUPLICATION: int = ...
     _EDGE_SIZE: int = ...
@@ -244,7 +240,7 @@ class BaseGraph:
         )
         self._world2buffer = typed.Dict.empty(types.int64, types.int64)
         self._buffer2world = np.full(
-            n_nodes, fill_value=self._NODE_EMPTY_PTR, dtype=int
+            n_nodes, fill_value=_NODE_EMPTY_PTR, dtype=int
         )
         # edge-wise buffers
         self._empty_edge_idx = 0 if n_edges > 0 else _EDGE_EMPTY_PTR
@@ -322,7 +318,7 @@ class BaseGraph:
 
     def nodes(self) -> np.ndarray:
         """Indices of graph nodes."""
-        return self._buffer2world[self._buffer2world != self._NODE_EMPTY_PTR]
+        return self._buffer2world[self._buffer2world != _NODE_EMPTY_PTR]
 
     def coordinates(
         self, node_indices: Optional[ArrayLike] = None
@@ -367,7 +363,7 @@ class BaseGraph:
         )
         self._buffer2world = np.append(
             self._buffer2world,
-            np.full(size_diff, fill_value=self._NODE_EMPTY_PTR, dtype=int),
+            np.full(size_diff, fill_value=_NODE_EMPTY_PTR, dtype=int),
         )
         self._empty_nodes = list(reversed(range(prev_size, size)))
 
@@ -422,7 +418,7 @@ class BaseGraph:
             index = self._buffer2world[index]
         buffer_index = self._world2buffer.pop(index)
         self._remove_node_edges(buffer_index)
-        self._buffer2world[buffer_index] = self._NODE_EMPTY_PTR
+        self._buffer2world[buffer_index] = _NODE_EMPTY_PTR
         self._empty_nodes.append(buffer_index)
 
     @abstractmethod

--- a/src/napari_graph/_tests/test_graph.py
+++ b/src/napari_graph/_tests/test_graph.py
@@ -197,7 +197,7 @@ class TestDirectedGraph(TestGraph):
             assert len(self.graph) == original_size - i - 1
 
     def test_edge_coordinates(self) -> None:
-        coords = self.coords.values[self.edges]
+        coords = self.coords.to_numpy()[self.edges]
 
         source_edge_coords = np.concatenate(
             self.graph.source_edges(mode='coords'), axis=0
@@ -254,7 +254,7 @@ class TestUndirectedGraph(TestGraph):
         for node, coords in zip(self.graph.nodes(), edge_coords):
             for i, edge in enumerate(self.graph.edges(node)):
                 assert np.allclose(
-                    self.coords.loc[edge, ["y", "x"]].values, coords[i]
+                    self.coords.loc[edge, ["y", "x"]].to_numpy(), coords[i]
                 )
 
     def assert_empty_linked_list_pairs_are_neighbors(self) -> None:

--- a/src/napari_graph/directed_graph.py
+++ b/src/napari_graph/directed_graph.py
@@ -6,6 +6,7 @@ from numba import njit, typed
 from numpy.typing import ArrayLike
 
 from napari_graph._base_graph import (
+    _NODE_EMPTY_PTR,
     _EDGE_EMPTY_PTR,
     BaseGraph,
     _iterate_edges,
@@ -381,7 +382,7 @@ class DirectedGraph(BaseGraph):
         super()._realloc_nodes_buffers(size)
         self._node2tgt_edges = np.append(
             self._node2tgt_edges,
-            np.full(diff_size, fill_value=self._NODE_EMPTY_PTR, dtype=int),
+            np.full(diff_size, fill_value=_NODE_EMPTY_PTR, dtype=int),
         )
 
     def _add_edges(self, edges: np.ndarray) -> None:

--- a/src/napari_graph/directed_graph.py
+++ b/src/napari_graph/directed_graph.py
@@ -349,16 +349,13 @@ class DirectedGraph(BaseGraph):
     _EDGE_SIZE = _DI_EDGE_SIZE
     _LL_EDGE_POS = _LL_DI_EDGE_POS
 
-    def _init_buffers(self, n_nodes: int, n_edges: int) -> None:
-        super()._init_buffers(n_nodes, n_edges)
+    def _init_node_buffers(self, n_nodes: int) -> None:
+        super()._init_node_buffers(n_nodes)
         self._node2tgt_edges = np.full(
             n_nodes, fill_value=_EDGE_EMPTY_PTR, dtype=int
         )
 
-    def init_data_from_dataframe(
-        self,
-        coords: Union[pd.DataFrame, ArrayLike],
-    ) -> None:
+    def init_nodes(self, coords: Union[pd.DataFrame, ArrayLike]) -> None:
         """Initialize graph nodes from dataframe.
 
         Graph nodes will be indexed by dataframe indices.
@@ -368,7 +365,7 @@ class DirectedGraph(BaseGraph):
         coords : pd.DataFrame
             Data frame containing nodes coordinates.
         """
-        super().init_data_from_dataframe(coords)
+        super().init_nodes(coords)
         n_nodes = len(coords)
         if len(self._node2tgt_edges) < n_nodes:
             self._node2tgt_edges = np.full(


### PR DESCRIPTION
Hi @JoOkuma

I found the `BaseGraph.__init__` a bit hard to parse, so I've refactored it a bit.

Additionally, this PR includes the following changes:
- `ndim` can now be specified together with `coords` (has to match)
- `_init_buffers` has been split up into `_init_node_buffers` and `_init_edge_buffers`
- `init_data_from_dataframe` has been renamed to `init_nodes`

Nothing really major, and I'm also happy to keep your original version. Let me know what you think!